### PR TITLE
Update channel to conversations

### DIFF
--- a/src/functions.ts
+++ b/src/functions.ts
@@ -2,7 +2,7 @@ import app from './initBolt'
 
 export const getChannelsList = async ({ token }) => {
   try {
-    const getChannelsListResponce: any = await app.client.channels.list({
+    const getChannelsListResponce: any = await app.client.conversations.list({
       token: token
     })
 


### PR DESCRIPTION
https://api.slack.com/changelog/2020-01-deprecating-antecedents-to-the-conversations-api の対応