### PR TITLE
Update for octokit

### DIFF
--- a/src/equalizer/getDataFromGitHub.ts
+++ b/src/equalizer/getDataFromGitHub.ts
@@ -1,5 +1,5 @@
 const getDataFromGitHub = async (path: string, octokit) => {
-  const buffer = await octokit.repos.getContents({
+  const buffer = await octokit.repos.getContent({
     owner: 'skryu-studio',
     repo: 'equalizer',
     ref: 'heads/master',

--- a/src/equalizer/setupData.ts
+++ b/src/equalizer/setupData.ts
@@ -1,4 +1,4 @@
-import { Octokit, RestEndpointMethodTypes } from '@octokit/rest'
+import { Octokit } from '@octokit/rest'
 import * as dotenv from 'dotenv'
 
 import getDataFromGitHub from './getDataFromGitHub'


### PR DESCRIPTION
🐛 fix(getDataFromGitHub.ts): fix typo in method name from octokit.repos.getContents to octokit.repos.getContent for retrieving data from GitHub API

🔥 refactor(setupData.ts): remove unused import RestEndpointMethodTypes from @octokit/rest library and dotenv library