### PR TITLE
メンション反応を Anthropic Claude に移行（OpenAI フォールバック付き）

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "@anthropic-ai/sdk": "^0.98.0",
         "@octokit/rest": "^20.1.0",
         "@slack/bolt": "^3.18.0",
         "@types/node": "^25.5.0",
@@ -26,6 +27,26 @@
         "@types/jsdom": "^27.0.0",
         "@types/turndown": "^5.0.4",
         "lint-staged": "^16.0.0"
+      }
+    },
+    "node_modules/@anthropic-ai/sdk": {
+      "version": "0.98.0",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.98.0.tgz",
+      "integrity": "sha512-N7aXtCvC5g6T1Y4V29lJjceu/zTkVkIZF0jdBvagr0TRFHuKeImffalGWEfqZKrvjH+IQbzJWw6TmSmUzrlMgg==",
+      "dependencies": {
+        "json-schema-to-ts": "^3.1.1",
+        "standardwebhooks": "^1.0.0"
+      },
+      "bin": {
+        "anthropic-ai-sdk": "bin/cli"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
       }
     },
     "node_modules/@asamuzakjp/css-color": {
@@ -74,6 +95,14 @@
       "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
       "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
       "license": "MIT"
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+      "engines": {
+        "node": ">=6.9.0"
+      }
     },
     "node_modules/@bramus/specificity": {
       "version": "2.4.2",
@@ -583,6 +612,11 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.2.tgz",
       "integrity": "sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q=="
+    },
+    "node_modules/@stablelib/base64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
+      "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ=="
     },
     "node_modules/@tsconfig/node10": {
       "version": "1.0.9",
@@ -1632,6 +1666,11 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/fast-sha256": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
+      "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ=="
+    },
     "node_modules/fill-range": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
@@ -2420,6 +2459,18 @@
       },
       "funding": {
         "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/json-schema-to-ts": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
+      "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "ts-algebra": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/jsonwebtoken": {
@@ -3392,6 +3443,15 @@
         "source-map": "^0.6.0"
       }
     },
+    "node_modules/standardwebhooks": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.0.0.tgz",
+      "integrity": "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==",
+      "dependencies": {
+        "@stablelib/base64": "^1.0.0",
+        "fast-sha256": "^1.3.0"
+      }
+    },
     "node_modules/statuses": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
@@ -3594,6 +3654,11 @@
       "bin": {
         "tree-kill": "cli.js"
       }
+    },
+    "node_modules/ts-algebra": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
+      "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw=="
     },
     "node_modules/ts-node": {
       "version": "10.9.2",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   },
   "homepage": "https://github.com/sKawashima/Kirika#readme",
   "dependencies": {
+    "@anthropic-ai/sdk": "^0.98.0",
     "@octokit/rest": "^20.1.0",
     "@slack/bolt": "^3.18.0",
     "@types/node": "^25.5.0",

--- a/src/mentionResponse/generateMessage.ts
+++ b/src/mentionResponse/generateMessage.ts
@@ -15,12 +15,6 @@ const ANTHROPIC_MODEL = 'claude-sonnet-4-6'
 const ANTHROPIC_MAX_TOKENS = 64000 // Sonnet 4.6 同期 Messages API の出力上限
 const OPENAI_MODEL = 'gpt-4o'
 
-const extractText = (res: Anthropic.Message): string =>
-  res.content
-    .filter((b): b is Anthropic.TextBlock => b.type === 'text')
-    .map(b => b.text)
-    .join('')
-
 // Anthropic 側のサーバーエラー（5xx / 接続・タイムアウト）のときだけ true。
 // 4xx・認証・レート制限などリクエスト起因のエラーではフォールバックしない。
 const isAnthropicServerError = (error: unknown): boolean => {
@@ -76,8 +70,8 @@ const generate = async (
       messages: [{ role: 'user', content: text }],
       temperature: 0
     })
-    const res = await stream.finalMessage()
-    return extractText(res)
+    // 複数 text block も SDK と同じ join(' ') で連結する標準ヘルパーを使う
+    return await stream.finalText()
   } catch (error) {
     if (!isAnthropicServerError(error)) {
       return `エラーが発生しました。: ${error}`

--- a/src/mentionResponse/generateMessage.ts
+++ b/src/mentionResponse/generateMessage.ts
@@ -1,10 +1,35 @@
+import Anthropic from '@anthropic-ai/sdk'
 import { OpenAI } from 'openai'
 import dotenv from 'dotenv'
 dotenv.config()
 
+const anthropic = new Anthropic({
+  apiKey: process.env['ANTHROPIC_API_KEY']
+})
+
 const openai = new OpenAI({
   apiKey: process.env['OPENAI_API_KEY']
 })
+
+const ANTHROPIC_MODEL = 'claude-sonnet-4-6'
+const ANTHROPIC_MAX_TOKENS = 64000 // Sonnet 4.6 同期 Messages API の出力上限
+const OPENAI_MODEL = 'gpt-4o'
+
+const extractText = (res: Anthropic.Message): string =>
+  res.content
+    .filter((b): b is Anthropic.TextBlock => b.type === 'text')
+    .map(b => b.text)
+    .join('')
+
+// Anthropic 側のサーバーエラー（5xx / 接続・タイムアウト）のときだけ true。
+// 4xx・認証・レート制限などリクエスト起因のエラーではフォールバックしない。
+const isAnthropicServerError = (error: unknown): boolean => {
+  if (error instanceof Anthropic.APIConnectionError) return true
+  if (error instanceof Anthropic.APIError && typeof error.status === 'number') {
+    return error.status >= 500
+  }
+  return false
+}
 
 const SYSTEM_PROMPT = `
 You are an assistant that takes markdown text, summarizes the content, and answers questions about that content.
@@ -27,23 +52,6 @@ Answer in Japanese unless otherwise instructed by the user.
 Please use the ですます調 in Japanese.
 `
 
-export const generateSummaryMessage = async (text: string) => {
-  try {
-    const res = await openai.chat.completions.create({
-      model: 'gpt-4o',
-      messages: [
-        { role: 'system', content: SYSTEM_PROMPT },
-        { role: 'user', content: text }
-      ],
-      temperature: 0
-    })
-
-    return res.choices[0].message.content
-  } catch (error) {
-    return `エラーが発生しました。: ${error}`
-  }
-}
-
 const GENERAL_SYSTEM_PROMPT = `
 You are an excellent assistant.
 
@@ -53,19 +61,46 @@ When answering in Japanese, please use "アタシ" in the first person.
 You will answer in Japanese unless otherwise instructed by the user.
 `
 
-export const generateMessage = async (text: string) => {
+// Anthropic を主に応答を生成し、Anthropic 側のサーバーエラー時のみ OpenAI にフォールバックする。
+const generate = async (
+  systemPrompt: string,
+  text: string
+): Promise<string> => {
   try {
-    const res = await openai.chat.completions.create({
-      model: 'gpt-4o',
-      messages: [
-        { role: 'system', content: GENERAL_SYSTEM_PROMPT },
-        { role: 'user', content: text }
-      ],
+    // max_tokens が大きい（=API上限）と SDK は非ストリーミングを拒否するため
+    // ストリーミングで実行し、完了したメッセージ全体を受け取る（応答が短ければ即返る）。
+    const stream = anthropic.messages.stream({
+      model: ANTHROPIC_MODEL,
+      max_tokens: ANTHROPIC_MAX_TOKENS,
+      system: systemPrompt,
+      messages: [{ role: 'user', content: text }],
       temperature: 0
     })
-
-    return res.choices[0].message.content
+    const res = await stream.finalMessage()
+    return extractText(res)
   } catch (error) {
-    return `エラーが発生しました。: ${error}`
+    if (!isAnthropicServerError(error)) {
+      return `エラーが発生しました。: ${error}`
+    }
+    // Anthropic がサーバーエラー → OpenAI にフォールバック
+    try {
+      const res = await openai.chat.completions.create({
+        model: OPENAI_MODEL,
+        messages: [
+          { role: 'system', content: systemPrompt },
+          { role: 'user', content: text }
+        ],
+        temperature: 0
+      })
+      return res.choices[0].message.content ?? ''
+    } catch (fallbackError) {
+      return `エラーが発生しました。: ${fallbackError}`
+    }
   }
 }
+
+export const generateSummaryMessage = (text: string) =>
+  generate(SYSTEM_PROMPT, text)
+
+export const generateMessage = (text: string) =>
+  generate(GENERAL_SYSTEM_PROMPT, text)


### PR DESCRIPTION
## なぜやるか

メンション反応の生成を OpenAI `gpt-4o` から Anthropic Claude（`claude-sonnet-4-6`）へ移行するため。あわせて、Anthropic 側でサーバーエラーが起きても応答が途切れないよう、OpenAI をフォールバックとして残す。

## やったこと

- 依存に `@anthropic-ai/sdk`（v0.98.0）を追加（`openai` はフォールバック用に残置）
- メンション応答の生成を Anthropic Messages API（`claude-sonnet-4-6`）に切り替え
  - `max_tokens` を API 上限の `64000` に設定。これにより SDK が非ストリーミングを拒否するため、ストリーミング（`messages.stream().finalMessage()`）で実行（応答が短ければ即返る）
  - system プロンプトはトップレベルの `system` パラメータへ移動（文面は変更なし）
- Anthropic が**サーバーエラー（HTTP 5xx / 接続・タイムアウト）のときのみ** OpenAI `gpt-4o` にフォールバック。4xx・認証・レート制限などリクエスト起因のエラーではフォールバックしない
- ローカルで雑談（`generateMessage`）・要約（`generateSummaryMessage`）の両系統が Anthropic 経由で期待どおり応答することを確認

## やってないこと

- プロンプト文面の変更（据え置き）
- フォールバック経路の実機確認（Anthropic の 5xx を実際に再現できないため未検証。判定ロジックと OpenAI 呼び出し形は従来コードのまま）
- `OPENAI_API_KEY` の削除（フォールバックで引き続き使用するため残置）
- `type-check` スクリプト自体の改善（`--target`/`--skipLibCheck` 未指定で node_modules の `.d.ts` 警告が出るが、これは本PR以前からの既存事象のため対象外）

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **改善**
  * メッセージおよび要約の生成が新しいAI経路を主要に使うようになり、応答取得の安定性が向上しました。
  * 接続/タイムアウトおよび一部のサーバーエラー発生時のみ別経路へ自動で切り替わるようになり、サービス継続性と信頼性が改善されました。
  * エラー時の応答は明確化され、フォールバック時は既存の生成結果形式を維持します。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sKawashima/Kirika/pull/450?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->