### PR TITLE
✨ add web search tool to Claude mention responses

### DIFF
--- a/src/mentionResponse/generateMessage.ts
+++ b/src/mentionResponse/generateMessage.ts
@@ -23,6 +23,9 @@ const WEB_SEARCH_TOOL: Anthropic.Messages.WebSearchTool20250305 = {
   max_uses: 5 // 1 リクエストあたりの検索回数上限（コスト・レイテンシ抑制）
 }
 
+// pause_turn による継続リクエストの上限（初回 + 継続を含む。無限ループ防止）
+const MAX_TURNS = 5
+
 // Anthropic 側のサーバーエラー（5xx / 接続・タイムアウト）のときだけ true。
 // 4xx・認証・レート制限などリクエスト起因のエラーではフォールバックしない。
 const isAnthropicServerError = (error: unknown): boolean => {
@@ -62,16 +65,20 @@ const GENERAL_SYSTEM_PROMPT = `
 You are an excellent assistant.
 
 Please limit your response to 5 sentences or less, unless the user instructs you to "elaborate" or otherwise.
+Use the web_search tool only when answering requires up-to-date information or external facts you are not confident about; otherwise answer directly without searching.
 Please use the ですます調 in Japanese.
 When answering in Japanese, please use "アタシ" in the first person.
 You will answer in Japanese unless otherwise instructed by the user.
 `
 
-// 最終メッセージから本文を組み立て、Web 検索が使われた場合は出典 URL を末尾に付ける。
+// メッセージの content ブロックから本文テキストと出典を取り出し、集約先に追記する。
 // finalText() は citation を捨てるため、content ブロックを直接走査する。
-const formatMessage = (message: Anthropic.Messages.Message): string => {
-  const textParts: string[] = []
-  const sources = new Map<string, string>() // url -> title（重複排除）
+// pause_turn による複数ターンに跨る応答もここで蓄積できる。
+const collectContent = (
+  message: Anthropic.Messages.Message,
+  textParts: string[],
+  sources: Map<string, string> // url -> title（重複排除）
+): void => {
   for (const block of message.content) {
     if (block.type !== 'text') continue
     textParts.push(block.text)
@@ -81,6 +88,14 @@ const formatMessage = (message: Anthropic.Messages.Message): string => {
       }
     }
   }
+}
+
+// 蓄積した本文と出典から最終的な応答文字列を組み立てる。
+// 検索が使われた場合だけ末尾に出典 URL を付ける。
+const buildResult = (
+  textParts: string[],
+  sources: Map<string, string>
+): string => {
   // finalText() と同じく text block を join(' ') で連結する
   let result = textParts.join(' ').trim()
   if (sources.size > 0) {
@@ -99,19 +114,34 @@ const generate = async (
   text: string
 ): Promise<string> => {
   try {
-    // max_tokens が大きい（=API上限）と SDK は非ストリーミングを拒否するため
-    // ストリーミングで実行し、完了したメッセージ全体を受け取る（応答が短ければ即返る）。
-    // tools に Web 検索を渡すと、Claude が必要と判断したときだけ自動で検索する。
-    const stream = anthropic.messages.stream({
-      model: ANTHROPIC_MODEL,
-      max_tokens: ANTHROPIC_MAX_TOKENS,
-      system: systemPrompt,
-      messages: [{ role: 'user', content: text }],
-      tools: [WEB_SEARCH_TOOL],
-      temperature: 0
-    })
+    const messages: Anthropic.Messages.MessageParam[] = [
+      { role: 'user', content: text }
+    ]
+    const textParts: string[] = []
+    const sources = new Map<string, string>()
+    // Web 検索などサーバーツール使用時、長いターンは stop_reason='pause_turn' で
+    // 中断されることがある。その場合はアシスタントの途中経過を積み増してターンを
+    // 継続する（無限ループ防止のため MAX_TURNS で上限を設ける）。
+    for (let turn = 0; turn < MAX_TURNS; turn++) {
+      // max_tokens が大きい（=API上限）と SDK は非ストリーミングを拒否するため
+      // ストリーミングで実行し、完了したメッセージ全体を受け取る（応答が短ければ即返る）。
+      // tools に Web 検索を渡すと、Claude が必要と判断したときだけ自動で検索する。
+      const stream = anthropic.messages.stream({
+        model: ANTHROPIC_MODEL,
+        max_tokens: ANTHROPIC_MAX_TOKENS,
+        system: systemPrompt,
+        messages,
+        tools: [WEB_SEARCH_TOOL],
+        temperature: 0
+      })
+      const message = await stream.finalMessage()
+      collectContent(message, textParts, sources)
+      // pause_turn 以外（end_turn 等）で完了。pause_turn のときだけ継続する。
+      if (message.stop_reason !== 'pause_turn') break
+      messages.push({ role: 'assistant', content: message.content })
+    }
     // 本文を組み立て、検索が使われていれば出典 URL も付加する
-    return formatMessage(await stream.finalMessage())
+    return buildResult(textParts, sources)
   } catch (error) {
     if (!isAnthropicServerError(error)) {
       return `エラーが発生しました。: ${error}`

--- a/src/mentionResponse/generateMessage.ts
+++ b/src/mentionResponse/generateMessage.ts
@@ -15,6 +15,14 @@ const ANTHROPIC_MODEL = 'claude-sonnet-4-6'
 const ANTHROPIC_MAX_TOKENS = 64000 // Sonnet 4.6 同期 Messages API の出力上限
 const OPENAI_MODEL = 'gpt-4o'
 
+// サーバーサイド Web 検索ツール。検索は Anthropic 側で実行され、Claude が
+// 必要と判断したときだけ自動で使う（こちらで検索 API を実装する必要はない）。
+const WEB_SEARCH_TOOL: Anthropic.Messages.WebSearchTool20250305 = {
+  type: 'web_search_20250305',
+  name: 'web_search',
+  max_uses: 5 // 1 リクエストあたりの検索回数上限（コスト・レイテンシ抑制）
+}
+
 // Anthropic 側のサーバーエラー（5xx / 接続・タイムアウト）のときだけ true。
 // 4xx・認証・レート制限などリクエスト起因のエラーではフォールバックしない。
 const isAnthropicServerError = (error: unknown): boolean => {
@@ -35,10 +43,14 @@ You are an assistant that takes markdown text, summarizes the content, and answe
 *内容*
 <detailed summary (as much detail as possible)>
 
-## If the user asks a question, please answer it based on ArticleContents.
+## If the user asks a question, first try to answer it based on ArticleContents.
 The format is free.
 
-## If there is a question that is not in the article, please answer, "There is no information in the article," and provide no further information.
+## Only if the user's additional question cannot be answered from ArticleContents and requires looking up other documents or up-to-date external information, you may use the web_search tool to research it.
+Do not use web_search just to summarize the article, nor for questions that can already be answered from ArticleContents.
+The format is free.
+
+## If the answer still cannot be found even after that, please answer, "There is no information in the article," and provide no further information.
 The format is free.
 
 ## Communication Guidelines
@@ -55,6 +67,32 @@ When answering in Japanese, please use "アタシ" in the first person.
 You will answer in Japanese unless otherwise instructed by the user.
 `
 
+// 最終メッセージから本文を組み立て、Web 検索が使われた場合は出典 URL を末尾に付ける。
+// finalText() は citation を捨てるため、content ブロックを直接走査する。
+const formatMessage = (message: Anthropic.Messages.Message): string => {
+  const textParts: string[] = []
+  const sources = new Map<string, string>() // url -> title（重複排除）
+  for (const block of message.content) {
+    if (block.type !== 'text') continue
+    textParts.push(block.text)
+    for (const citation of block.citations ?? []) {
+      if (citation.type === 'web_search_result_location') {
+        sources.set(citation.url, citation.title ?? citation.url)
+      }
+    }
+  }
+  // finalText() と同じく text block を join(' ') で連結する
+  let result = textParts.join(' ').trim()
+  if (sources.size > 0) {
+    const lines = Array.from(
+      sources,
+      ([url, title]) => `• <${url}|${title}>`
+    )
+    result += `\n\n*出典*\n${lines.join('\n')}`
+  }
+  return result
+}
+
 // Anthropic を主に応答を生成し、Anthropic 側のサーバーエラー時のみ OpenAI にフォールバックする。
 const generate = async (
   systemPrompt: string,
@@ -63,15 +101,17 @@ const generate = async (
   try {
     // max_tokens が大きい（=API上限）と SDK は非ストリーミングを拒否するため
     // ストリーミングで実行し、完了したメッセージ全体を受け取る（応答が短ければ即返る）。
+    // tools に Web 検索を渡すと、Claude が必要と判断したときだけ自動で検索する。
     const stream = anthropic.messages.stream({
       model: ANTHROPIC_MODEL,
       max_tokens: ANTHROPIC_MAX_TOKENS,
       system: systemPrompt,
       messages: [{ role: 'user', content: text }],
+      tools: [WEB_SEARCH_TOOL],
       temperature: 0
     })
-    // 複数 text block も SDK と同じ join(' ') で連結する標準ヘルパーを使う
-    return await stream.finalText()
+    // 本文を組み立て、検索が使われていれば出典 URL も付加する
+    return formatMessage(await stream.finalMessage())
   } catch (error) {
     if (!isAnthropicServerError(error)) {
       return `エラーが発生しました。: ${error}`


### PR DESCRIPTION
## なぜやるか

メンション応答の Claude 呼び出しはこれまでツールを一切使っておらず、モデルの知識カットオフ以降の最新情報や Web 上の事実を答えられなかった。Claude が「必要と判断したときだけ」自動で Web 検索し、最新情報を踏まえて回答できるようにする。

## やったこと

- 共有の `generate()` に Anthropic のサーバーサイド Web 検索ツール（`web_search_20250305` / `max_uses: 5`）を渡し、要約・一般会話の両パスで Claude が必要時のみ自動検索するようにした（検索は Anthropic 側で実行されるため、こちらでの検索処理実装は不要）。
- `finalText()` → `finalMessage()` に切り替え、Web 検索が使われた応答には参照元 URL を `*出典*` セクションとして末尾に付加（Slack mrkdwn リンク `<url|title>`）。本文の連結は従来と同じ `join(' ')` を踏襲。
- 要約用システムプロンプトを調整し、記事だけでは答えられない追加質問で外部情報の調査が必要なときのみ検索が発火するようにした（要約そのものや記事内で答えられる質問では検索しない）。

## やってないこと

- OpenAI フォールバック（gpt-4o）は Web 検索非対応のまま（Anthropic のサーバーエラー時のみの劣化経路のため許容）。
- `pause_turn` の自動継続ループは未実装（`max_uses: 5` と短い応答では通常発生しないため）。
- 動的フィルタリング版（`web_search_20260209`）は未採用（code execution ツールの併用が必須で複雑なため、基本版を採用）。
- Claude Console での組織の Web 検索有効化はコード外設定（管理者対応が前提。無効だとツール付きリクエストがエラーになる）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * Web検索の結果に出典（URL・タイトル）が表示されるようになりました。
  * レスポンスの最後に検索で参照したソース情報が「*出典*」として追加されます。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sKawashima/Kirika/pull/452?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->