### PR TITLE
メンション返答のURL処理を改善

### DIFF
--- a/src/mentionResponse/fetchText.ts
+++ b/src/mentionResponse/fetchText.ts
@@ -63,5 +63,6 @@ const parseHTMLToMarkdown = (html: string) => {
 
 export const fetchTextFromUrls = async (urls: string[]) => {
   const fetchedTexts = await Promise.all(urls.map(fetchText))
-  return fetchedTexts.join('\n---\n')
+  const validTexts = fetchedTexts.filter((t): t is string => t !== null)
+  return validTexts.length > 0 ? validTexts.join('\n---\n') : null
 }

--- a/src/mentionResponse/fetchText.ts
+++ b/src/mentionResponse/fetchText.ts
@@ -63,6 +63,9 @@ const parseHTMLToMarkdown = (html: string) => {
 
 export const fetchTextFromUrls = async (urls: string[]) => {
   const fetchedTexts = await Promise.all(urls.map(fetchText))
-  const validTexts = fetchedTexts.filter((t): t is string => t !== null)
+  const validTexts = fetchedTexts
+    .filter((t): t is string => t !== null)
+    .map(t => t.trim())
+    .filter(t => t.length > 0)
   return validTexts.length > 0 ? validTexts.join('\n---\n') : null
 }

--- a/src/mentionResponse/generateMessage.ts
+++ b/src/mentionResponse/generateMessage.ts
@@ -181,8 +181,15 @@ Please use the ですます調 in Japanese.
 export const generateSummaryMessage = (text: string) =>
   generate(SYSTEM_PROMPT, text)
 
-export const generateSummaryMessageFromUrls = (urls: string[]) =>
-  generate(URL_FALLBACK_SYSTEM_PROMPT, urls.join('\n'))
+export const generateSummaryMessageFromUrls = (
+  urls: string[],
+  conversationContext?: string
+) => {
+  const input = conversationContext
+    ? `URLs:\n${urls.join('\n')}\n\n---\nPast Conversations:\n${conversationContext}`
+    : urls.join('\n')
+  return generate(URL_FALLBACK_SYSTEM_PROMPT, input)
+}
 
 export const generateMessage = (text: string) =>
   generate(GENERAL_SYSTEM_PROMPT, text)

--- a/src/mentionResponse/generateMessage.ts
+++ b/src/mentionResponse/generateMessage.ts
@@ -163,8 +163,26 @@ const generate = async (
   }
 }
 
+const URL_FALLBACK_SYSTEM_PROMPT = `
+You are an assistant that summarizes web pages.
+The user will provide URLs that could not be fetched directly.
+Please use the web_search tool to look up the content of each URL and provide a summary:
+
+*3行まとめ*
+<short and simple three-sentence summary (break line after each sentence)>
+
+*内容*
+<detailed summary (as much detail as possible)>
+
+Answer in Japanese unless otherwise instructed by the user.
+Please use the ですます調 in Japanese.
+`
+
 export const generateSummaryMessage = (text: string) =>
   generate(SYSTEM_PROMPT, text)
+
+export const generateSummaryMessageFromUrls = (urls: string[]) =>
+  generate(URL_FALLBACK_SYSTEM_PROMPT, urls.join('\n'))
 
 export const generateMessage = (text: string) =>
   generate(GENERAL_SYSTEM_PROMPT, text)

--- a/src/mentionResponse/index.ts
+++ b/src/mentionResponse/index.ts
@@ -34,7 +34,9 @@ export const mentionResponse = async ({
 
     say({
       text: message,
-      thread_ts
+      thread_ts,
+      unfurl_links: false,
+      unfurl_media: false
     })
   } else {
     const replies = await client.conversations.replies({
@@ -74,7 +76,9 @@ export const mentionResponse = async ({
             : modifiedMessage.endsWith('。\n')
             ? modifiedMessage.slice(0, -2) + desuReplacement()
             : modifiedMessage + desuReplacement(),
-        thread_ts
+        thread_ts,
+        unfurl_links: false,
+        unfurl_media: false
       })
       return
     }
@@ -101,7 +105,9 @@ ${replies.messages
 
     say({
       text: message,
-      thread_ts
+      thread_ts,
+      unfurl_links: false,
+      unfurl_media: false
     })
   }
 }

--- a/src/mentionResponse/index.ts
+++ b/src/mentionResponse/index.ts
@@ -91,7 +91,12 @@ ${replies.messages
   .map(m => `${m.display_as_bot ? 'bot' : 'user'}: ${m.text}`)
   .join('\n---\n') + '\n---\n' + `user: ${event.text}`}
 `)
-      : await generateSummaryMessageFromUrls(urlInReplies)
+      : await generateSummaryMessageFromUrls(
+          urlInReplies,
+          replies.messages
+            .map(m => `${m.display_as_bot ? 'bot' : 'user'}: ${m.text}`)
+            .join('\n---\n') + '\n---\n' + `user: ${event.text}`
+        )
 
     say({
       text: message,

--- a/src/mentionResponse/index.ts
+++ b/src/mentionResponse/index.ts
@@ -1,6 +1,6 @@
 import { AppMentionEvent, Context, SayFn } from '@slack/bolt'
 import { fetchTextFromUrls } from './fetchText'
-import { generateMessage, generateSummaryMessage } from './generateMessage'
+import { generateMessage, generateSummaryMessage, generateSummaryMessageFromUrls } from './generateMessage'
 import { getUrl } from './getUrl'
 import { StringIndexed } from '@slack/bolt/dist/types/helpers'
 import { WebClient } from '@slack/web-api'
@@ -23,7 +23,9 @@ export const mentionResponse = async ({
   if (urls.length > 0) {
     const fetchedMarkdowns = await fetchTextFromUrls(urls)
 
-    const message = await generateSummaryMessage(fetchedMarkdowns || urls.join('\n'))
+    const message = fetchedMarkdowns
+      ? await generateSummaryMessage(fetchedMarkdowns)
+      : await generateSummaryMessageFromUrls(urls)
 
     say({
       text: message,
@@ -78,9 +80,10 @@ export const mentionResponse = async ({
 
     const fetchedMarkdowns = await fetchTextFromUrls(urlInReplies)
 
-    const message = await generateSummaryMessage(`
+    const message = fetchedMarkdowns
+      ? await generateSummaryMessage(`
 ArticleContents:
-${fetchedMarkdowns || urlInReplies.join('\n')}
+${fetchedMarkdowns}
 
 ---
 Past Conversations:
@@ -88,6 +91,7 @@ ${replies.messages
   .map(m => `${m.display_as_bot ? 'bot' : 'user'}: ${m.text}`)
   .join('\n---\n') + '\n---\n' + `user: ${event.text}`}
 `)
+      : await generateSummaryMessageFromUrls(urlInReplies)
 
     say({
       text: message,

--- a/src/mentionResponse/index.ts
+++ b/src/mentionResponse/index.ts
@@ -22,15 +22,8 @@ export const mentionResponse = async ({
 
   if (urls.length > 0) {
     const fetchedMarkdowns = await fetchTextFromUrls(urls)
-    if (!fetchedMarkdowns) {
-      say({
-        text: 'エラー：URLのサーバーに弾かれたためページを取得できませんでした',
-        thread_ts
-      })
-      return
-    }
 
-    const message = await generateSummaryMessage(fetchedMarkdowns)
+    const message = await generateSummaryMessage(fetchedMarkdowns || urls.join('\n'))
 
     say({
       text: message,
@@ -84,17 +77,10 @@ export const mentionResponse = async ({
     }
 
     const fetchedMarkdowns = await fetchTextFromUrls(urlInReplies)
-    if (!fetchedMarkdowns) {
-      say({
-        text: 'エラー：URLのサーバーに弾かれたためページを取得できませんでした',
-        thread_ts
-      })
-      return
-    }
 
     const message = await generateSummaryMessage(`
 ArticleContents:
-${fetchedMarkdowns}
+${fetchedMarkdowns || urlInReplies.join('\n')}
 
 ---
 Past Conversations:


### PR DESCRIPTION
## なぜやるか

ClaudeのAPIから返ってきたメッセージにURLが含まれる場合（特に出典URLリスト）、SlackがデフォルトでOGP展開してしまい見づらくなっていた。またURLのフェッチが失敗した場合にエラーメッセージを返して処理を終了していたが、AnthropicのWeb Searchツールがあればそのままリカバリできる可能性がある。

## やったこと

- Anthropic APIの応答を投稿する `say()` 呼び出し3箇所に `unfurl_links: false, unfurl_media: false` を追加し、OGP展開を無効化
- URLのフェッチ（`fetchTextFromUrls`）が失敗したときのエラー表示と早期returnを削除し、取得できなかった場合はURLそのものをAnthropicに渡すフォールバックに変更（Claude側のweb_searchツールで解決できる可能性があるため）

## やってないこと

- web_searchで解決できなかった場合のハンドリング（Claudeが自力で判断して回答する想定）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * URLからのテキスト取得に失敗しても、Web検索を使ったフォールバックで要約を生成できるようにしました。
  * URL取得結果の整形（無効な値の除外・結合条件の調整）を見直し、要約対象の精度を改善しました。

* **挙動変更**
  * スレッド／投稿内のリンク・メディアの自動展開（unfurl）を抑制するようにしました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->