### PR TITLE
feat: add slot machine feature

### DIFF
--- a/src/messages.ts
+++ b/src/messages.ts
@@ -111,8 +111,8 @@ const initMessages = () => {
     }
 
     for (const { nums, jackpot } of rounds) {
-      if (desuflash && !jackpot) {
-        while (Math.random() < 0.5) await desuPost()
+      if (desuflash && jackpot && Math.random() < 0.5) {
+        await desuPost()
       }
 
       if (jackpot) {

--- a/src/messages.ts
+++ b/src/messages.ts
@@ -85,7 +85,7 @@ const initMessages = () => {
   })
 
   app.message(/slot/, async ({ say, message }) => {
-    const thread_ts = message.ts
+    const thread_ts = message.thread_ts || message.ts
     const sleep = (ms: number) => new Promise(resolve => setTimeout(resolve, ms))
 
     const rolls: number[][] = []

--- a/src/messages.ts
+++ b/src/messages.ts
@@ -88,42 +88,44 @@ const initMessages = () => {
     const thread_ts = message.ts
     const sleep = (ms: number) => new Promise(resolve => setTimeout(resolve, ms))
 
-    const rounds: { nums: number[]; jackpot: boolean }[] = []
+    const rolls: number[][] = []
+    let hasJackpot = false
     for (let i = 0; i < 10; i++) {
-      const nums = [0, 1, 2].map(() => Math.floor(Math.random() * 7) + 1)
-      const jackpot = nums[0] === nums[1] && nums[1] === nums[2]
-      rounds.push({ nums, jackpot })
-      if (jackpot) break
+      const roll = Array.from({ length: 3 }, () => Math.floor(Math.random() * 7) + 1)
+      rolls.push(roll)
+      if (roll[0] === roll[1] && roll[1] === roll[2]) {
+        hasJackpot = true
+        break
+      }
     }
 
-    const hasJackpot = rounds[rounds.length - 1].jackpot
     const desuflash = hasJackpot && Math.random() < 1 / 10
 
-    let first = true
+    let isFirst = true
     const post = async (text: string) => {
-      if (!first) await sleep(1000)
-      first = false
+      if (!isFirst) await sleep(1000)
+      isFirst = false
       await say({ text, thread_ts })
     }
 
-    const desuPost = async () => {
-      await post(Math.random() < 1 / 10 ? ':dededede-su:' : ':desu:')
-    }
-
-    for (const { nums, jackpot } of rounds) {
-      if (desuflash && jackpot && Math.random() < 0.5) {
-        await desuPost()
-      }
-
+    for (const roll of rolls) {
+      const jackpot = roll[0] === roll[1] && roll[1] === roll[2]
       if (jackpot) {
+        if (desuflash && Math.random() < 0.5) {
+          await post(Math.random() < 1 / 10 ? ':dededede-su:' : ':desu:')
+        }
         const display = Math.random() < 1 / 400
-          ? ['HMP', 'なまこ'][Math.floor(Math.random() * 2)]
-          : nums.join(' ')
+          ? (['HMP', 'なまこ'] as const)[Math.floor(Math.random() * 2)]
+          : roll.join(' ')
         await post(`${display}\n大当たり:de-su:`)
         return
       }
-
-      await post(nums.join(' '))
+      if (desuflash) {
+        while (Math.random() < 0.5) {
+          await post(Math.random() < 1 / 10 ? ':dededede-su:' : ':desu:')
+        }
+      }
+      await post(roll.join(' '))
     }
 
     await post('ハズレ:desu:⋯')

--- a/src/messages.ts
+++ b/src/messages.ts
@@ -85,6 +85,7 @@ const initMessages = () => {
   })
 
   app.message(/slot/, async ({ say, message }) => {
+    // @ts-ignore
     const thread_ts = message.thread_ts || message.ts
     const sleep = (ms: number) => new Promise(resolve => setTimeout(resolve, ms))
 

--- a/src/messages.ts
+++ b/src/messages.ts
@@ -83,6 +83,51 @@ const initMessages = () => {
     const result = await diceroll(message.text)
     await say(result)
   })
+
+  app.message(/slot/, async ({ say, message }) => {
+    const thread_ts = message.ts
+    const sleep = (ms: number) => new Promise(resolve => setTimeout(resolve, ms))
+
+    const rounds: { nums: number[]; jackpot: boolean }[] = []
+    for (let i = 0; i < 10; i++) {
+      const nums = [0, 1, 2].map(() => Math.floor(Math.random() * 7) + 1)
+      const jackpot = nums[0] === nums[1] && nums[1] === nums[2]
+      rounds.push({ nums, jackpot })
+      if (jackpot) break
+    }
+
+    const hasJackpot = rounds[rounds.length - 1].jackpot
+    const desuflash = hasJackpot && Math.random() < 1 / 10
+
+    let first = true
+    const post = async (text: string) => {
+      if (!first) await sleep(1000)
+      first = false
+      await say({ text, thread_ts })
+    }
+
+    const desuPost = async () => {
+      await post(Math.random() < 1 / 10 ? ':dededede-su:' : ':desu:')
+    }
+
+    for (const { nums, jackpot } of rounds) {
+      if (desuflash && !jackpot) {
+        while (Math.random() < 0.5) await desuPost()
+      }
+
+      if (jackpot) {
+        const display = Math.random() < 1 / 400
+          ? ['HMP', 'なまこ'][Math.floor(Math.random() * 2)]
+          : nums.join(' ')
+        await post(`${display}\n大当たり:de-su:`)
+        return
+      }
+
+      await post(nums.join(' '))
+    }
+
+    await post('ハズレ:desu:⋯')
+  })
 }
 
 export default initMessages


### PR DESCRIPTION
## なぜやるか

`slot` と投稿されたときにスロットを回して結果をスレッドに返す機能が欲しかったため。

## やったこと

- `slot` を含む投稿に反応するメッセージハンドラーを追加
- 1〜7 の数字を3つ、最大10ラウンド引いて1秒ごとに個別投稿
- 3つ一致で大当たり、その行に `大当たり:de-su:` を付けて早期終了
- 10ラウンド全外れで `ハズレ:desu:⋯` を投稿
- 大当たり時に 1/10 の確率で desuflash 状態になり、各行の前に 1/2 の確率で `:desu:` （さらに 1/10 で `:dededede-su:`）を挟む
- 大当たり行の前後には desuflash が出ない
- 1/400 の確率で大当たりの数字が `HMP` または `なまこ` に置き換わる
- テストスクリプト (`test-slot.ts`) とプレビュースクリプト (`preview-slot.ts`) を追加

## やってないこと

- 既存ハンドラーへの影響テスト
- Slack への結合テスト

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * `/slot/` に反応し、スレッド内で最大10回まで乱数3ロールを生成。最初に3つが一致した時点で抽選を確定します。
  * 当たりの場合は「大当たり:de-su:」とともに、条件を満たすと追加入力（`:dededede-su:`やレア文言）を段階的に投稿します。
  * はずれの場合は結果を順次投稿し、最後に「ハズレ:desu:⋯」を表示します。
* **改善**
  * 投稿は2回目以降、スレッド内で一定間隔を空けて行います。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->