### PR TITLE
feat: slot machine adjustments

### DIFF
--- a/src/messages.ts
+++ b/src/messages.ts
@@ -111,8 +111,8 @@ const initMessages = () => {
     }
 
     for (const { nums, jackpot } of rounds) {
-      if (desuflash && !jackpot) {
-        while (Math.random() < 0.5) await desuPost()
+      if (desuflash && jackpot && Math.random() < 0.5) {
+        await desuPost()
       }
 
       if (jackpot) {

--- a/src/messages.ts
+++ b/src/messages.ts
@@ -85,51 +85,63 @@ const initMessages = () => {
   })
 
   app.message(/slot/, async ({ say, message }) => {
+    const msg = message as any
     // @ts-ignore
-    const thread_ts = message.thread_ts || message.ts
+    const thread_ts = msg.thread_ts || message.ts
     const sleep = (ms: number) => new Promise(resolve => setTimeout(resolve, ms))
 
-    const rolls: number[][] = []
-    let hasJackpot = false
-    for (let i = 0; i < 10; i++) {
-      const roll = Array.from({ length: 3 }, () => Math.floor(Math.random() * 7) + 1)
-      rolls.push(roll)
-      if (roll[0] === roll[1] && roll[1] === roll[2]) {
-        hasJackpot = true
-        break
+    const countMatch = (msg.text as string || '').match(/slot\s+(\d+)/)
+    const count = countMatch ? Math.min(parseInt(countMatch[1], 10), 100) : 10
+
+    // 事前計算: 大当たりが出たランで打ち切り
+    const games: { rolls: number[][], desuflash: boolean }[] = []
+    for (let r = 0; r < count; r++) {
+      const rolls: number[][] = []
+      let hasJackpot = false
+      for (let i = 0; i < 10; i++) {
+        const roll = Array.from({ length: 3 }, () => Math.floor(Math.random() * 7) + 1)
+        rolls.push(roll)
+        if (roll[0] === roll[1] && roll[1] === roll[2]) {
+          hasJackpot = true
+          break
+        }
       }
+      const desuflash = hasJackpot && Math.random() < 1 / 10
+      games.push({ rolls, desuflash })
+      if (hasJackpot) break
     }
 
-    const desuflash = hasJackpot && Math.random() < 1 / 10
-
+    // 投稿
     let isFirst = true
     const post = async (text: string) => {
-      if (!isFirst) await sleep(1000)
+      if (!isFirst) await sleep(500)
       isFirst = false
       await say({ text, thread_ts })
     }
 
-    for (const roll of rolls) {
-      const jackpot = roll[0] === roll[1] && roll[1] === roll[2]
-      if (jackpot) {
-        if (desuflash && Math.random() < 0.5) {
-          await post(Math.random() < 1 / 10 ? ':dededede-su:' : ':desu:')
+    for (const { rolls, desuflash } of games) {
+      for (let i = 0; i < rolls.length; i++) {
+        const roll = rolls[i]
+        const jackpot = roll[0] === roll[1] && roll[1] === roll[2]
+        if (jackpot) {
+          if (desuflash && Math.random() < 0.5) {
+            await post(Math.random() < 1 / 10 ? ':dededede-su:' : ':desu:')
+          }
+          const display = Math.random() < 1 / 400
+            ? (['HMP', 'なまこ'] as const)[Math.floor(Math.random() * 2)]
+            : roll.join(' ')
+          await post(`${display}\n大当たり:de-su:`)
+          return
         }
-        const display = Math.random() < 1 / 400
-          ? (['HMP', 'なまこ'] as const)[Math.floor(Math.random() * 2)]
-          : roll.join(' ')
-        await post(`${display}\n大当たり:de-su:`)
-        return
-      }
-      if (desuflash) {
-        while (Math.random() < 0.5) {
-          await post(Math.random() < 1 / 10 ? ':dededede-su:' : ':desu:')
+        if (desuflash) {
+          while (Math.random() < 0.5) {
+            await post(Math.random() < 1 / 10 ? ':dededede-su:' : ':desu:')
+          }
         }
+        const isLast = i === rolls.length - 1
+        await post(isLast ? `${roll.join(' ')}\nハズレ:desu:⋯` : roll.join(' '))
       }
-      await post(roll.join(' '))
     }
-
-    await post('ハズレ:desu:⋯')
   })
 }
 

--- a/src/messages.ts
+++ b/src/messages.ts
@@ -85,7 +85,7 @@ const initMessages = () => {
   })
 
   app.message(/slot/, async ({ say, message }) => {
-    const thread_ts = message.ts
+    const thread_ts = message.thread_ts || message.ts
     const sleep = (ms: number) => new Promise(resolve => setTimeout(resolve, ms))
 
     const rolls: number[][] = []

--- a/src/messages.ts
+++ b/src/messages.ts
@@ -88,42 +88,44 @@ const initMessages = () => {
     const thread_ts = message.ts
     const sleep = (ms: number) => new Promise(resolve => setTimeout(resolve, ms))
 
-    const rounds: { nums: number[]; jackpot: boolean }[] = []
+    const rolls: number[][] = []
+    let hasJackpot = false
     for (let i = 0; i < 10; i++) {
-      const nums = [0, 1, 2].map(() => Math.floor(Math.random() * 7) + 1)
-      const jackpot = nums[0] === nums[1] && nums[1] === nums[2]
-      rounds.push({ nums, jackpot })
-      if (jackpot) break
+      const roll = Array.from({ length: 3 }, () => Math.floor(Math.random() * 7) + 1)
+      rolls.push(roll)
+      if (roll[0] === roll[1] && roll[1] === roll[2]) {
+        hasJackpot = true
+        break
+      }
     }
 
-    const hasJackpot = rounds[rounds.length - 1].jackpot
     const desuflash = hasJackpot && Math.random() < 1 / 10
 
-    let first = true
+    let isFirst = true
     const post = async (text: string) => {
-      if (!first) await sleep(1000)
-      first = false
+      if (!isFirst) await sleep(1000)
+      isFirst = false
       await say({ text, thread_ts })
     }
 
-    const desuPost = async () => {
-      await post(Math.random() < 1 / 10 ? ':dededede-su:' : ':desu:')
-    }
-
-    for (const { nums, jackpot } of rounds) {
-      if (desuflash && jackpot && Math.random() < 0.5) {
-        await desuPost()
-      }
-
+    for (const roll of rolls) {
+      const jackpot = roll[0] === roll[1] && roll[1] === roll[2]
       if (jackpot) {
+        if (desuflash && Math.random() < 0.5) {
+          await post(Math.random() < 1 / 10 ? ':dededede-su:' : ':desu:')
+        }
         const display = Math.random() < 1 / 400
-          ? ['HMP', 'なまこ'][Math.floor(Math.random() * 2)]
-          : nums.join(' ')
+          ? (['HMP', 'なまこ'] as const)[Math.floor(Math.random() * 2)]
+          : roll.join(' ')
         await post(`${display}\n大当たり:de-su:`)
         return
       }
-
-      await post(nums.join(' '))
+      if (desuflash) {
+        while (Math.random() < 0.5) {
+          await post(Math.random() < 1 / 10 ? ':dededede-su:' : ':desu:')
+        }
+      }
+      await post(roll.join(' '))
     }
 
     await post('ハズレ:desu:⋯')

--- a/src/messages.ts
+++ b/src/messages.ts
@@ -85,6 +85,7 @@ const initMessages = () => {
   })
 
   app.message(/slot/, async ({ say, message }) => {
+    // @ts-ignore
     const thread_ts = message.thread_ts || message.ts
     const sleep = (ms: number) => new Promise(resolve => setTimeout(resolve, ms))
 

--- a/src/messages.ts
+++ b/src/messages.ts
@@ -83,6 +83,51 @@ const initMessages = () => {
     const result = await diceroll(message.text)
     await say(result)
   })
+
+  app.message(/slot/, async ({ say, message }) => {
+    const thread_ts = message.ts
+    const sleep = (ms: number) => new Promise(resolve => setTimeout(resolve, ms))
+
+    const rounds: { nums: number[]; jackpot: boolean }[] = []
+    for (let i = 0; i < 10; i++) {
+      const nums = [0, 1, 2].map(() => Math.floor(Math.random() * 7) + 1)
+      const jackpot = nums[0] === nums[1] && nums[1] === nums[2]
+      rounds.push({ nums, jackpot })
+      if (jackpot) break
+    }
+
+    const hasJackpot = rounds[rounds.length - 1].jackpot
+    const desuflash = hasJackpot && Math.random() < 1 / 10
+
+    let first = true
+    const post = async (text: string) => {
+      if (!first) await sleep(1000)
+      first = false
+      await say({ text, thread_ts })
+    }
+
+    const desuPost = async () => {
+      await post(Math.random() < 1 / 10 ? ':dededede-su:' : ':desu:')
+    }
+
+    for (const { nums, jackpot } of rounds) {
+      if (desuflash && !jackpot) {
+        while (Math.random() < 0.5) await desuPost()
+      }
+
+      if (jackpot) {
+        const display = Math.random() < 1 / 400
+          ? ['HMP', 'なまこ'][Math.floor(Math.random() * 2)]
+          : nums.join(' ')
+        await post(`${display}\n大当たり:de-su:`)
+        return
+      }
+
+      await post(nums.join(' '))
+    }
+
+    await post('ハズレ:desu:⋯')
+  })
 }
 
 export default initMessages


### PR DESCRIPTION
## なぜやるか

スロット機能の挙動を細かく調整するため。

## やったこと

- スレッド内から起動した場合、親スレッドへ返信するよう修正（`thread_ts || ts`）
- 投稿間隔を 1000ms → 500ms に変更
- ハズレ時、最後のロール結果と `ハズレ:desu:⋯` を同一投稿に結合
- `slot 20` のように数字を渡すとその回数繰り返す（デフォルト10、最大100）
- 途中で大当たりが出たら繰り返しを即停止
- 全ランの事前計算を投稿より先に行うよう構造を明確化

## やってないこと

- 繰り返し中のハズレ・大当たりの集計表示