### PR TITLE
fix: jackpot前のdesuflashをwhile連投に変更

### DIFF
--- a/src/messages.ts
+++ b/src/messages.ts
@@ -88,10 +88,13 @@ const initMessages = () => {
     // @ts-ignore
     const thread_ts = message.thread_ts || message.ts
     const sleep = (ms: number) => new Promise(resolve => setTimeout(resolve, ms))
+    // @ts-ignore
+    const countMatch = (message.text as string || '').match(/slot\s+(\d+)/)
+    const count = countMatch ? Math.max(1, Math.min(parseInt(countMatch[1], 10), 1000)) : 10
 
     const rolls: number[][] = []
     let hasJackpot = false
-    for (let i = 0; i < 10; i++) {
+    for (let i = 0; i < count; i++) {
       const roll = Array.from({ length: 3 }, () => Math.floor(Math.random() * 7) + 1)
       rolls.push(roll)
       if (roll[0] === roll[1] && roll[1] === roll[2]) {

--- a/src/messages.ts
+++ b/src/messages.ts
@@ -109,7 +109,8 @@ const initMessages = () => {
       await say({ text, thread_ts })
     }
 
-    for (const roll of rolls) {
+    for (let i = 0; i < rolls.length; i++) {
+      const roll = rolls[i]
       const jackpot = roll[0] === roll[1] && roll[1] === roll[2]
       if (jackpot) {
         if (desuflash && Math.random() < 0.5) {
@@ -126,10 +127,9 @@ const initMessages = () => {
           await post(Math.random() < 1 / 10 ? ':dededede-su:' : ':desu:')
         }
       }
-      await post(roll.join(' '))
+      const isLast = i === rolls.length - 1
+      await post(isLast ? `${roll.join(' ')}\nハズレ:desu:⋯` : roll.join(' '))
     }
-
-    await post('ハズレ:desu:⋯')
   })
 }
 

--- a/src/messages.ts
+++ b/src/messages.ts
@@ -104,7 +104,7 @@ const initMessages = () => {
 
     let isFirst = true
     const post = async (text: string) => {
-      if (!isFirst) await sleep(1000)
+      if (!isFirst) await sleep(500)
       isFirst = false
       await say({ text, thread_ts })
     }

--- a/src/messages.ts
+++ b/src/messages.ts
@@ -116,7 +116,7 @@ const initMessages = () => {
       const roll = rolls[i]
       const jackpot = roll[0] === roll[1] && roll[1] === roll[2]
       if (jackpot) {
-        if (desuflash && Math.random() < 0.5) {
+        while (desuflash && Math.random() < 0.5) {
           await post(Math.random() < 1 / 10 ? ':dededede-su:' : ':desu:')
         }
         const display = Math.random() < 1 / 400


### PR DESCRIPTION
## なぜやるか
大当たり前のdesuflashが`if`だったため1回しか投稿されなかった。非大当たり行と同様に連投できるようにする。

## やったこと
- 大当たり前のdesuflash判定を`if`から`while`に変更

## やってないこと
- 非大当たり行のdesuflashロジックの変更（変更なし）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * `slot` の回数をコマンド入力で指定できるようになりました。
  * 指定がない場合は従来どおりデフォルト回数で実行されます。
  * `post` の投稿間隔が短くなり、よりテンポよく表示されるようになりました。

* **バグ修正**
  * 最後のロール時だけ、ハズレ表示を含む内容が適切に投稿されるようになりました。
  * それ以外のロールでは、必要最小限の表示のみを行うようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->