### PR TITLE
fix: desuflashの投稿間隔を250msに変更

### DIFF
--- a/src/messages.ts
+++ b/src/messages.ts
@@ -106,8 +106,8 @@ const initMessages = () => {
     const desuflash = hasJackpot && Math.random() < 1 / 10
 
     let isFirst = true
-    const post = async (text: string) => {
-      if (!isFirst) await sleep(500)
+    const post = async (text: string, ms = 500) => {
+      if (!isFirst) await sleep(ms)
       isFirst = false
       await say({ text, thread_ts })
     }
@@ -117,7 +117,7 @@ const initMessages = () => {
       const jackpot = roll[0] === roll[1] && roll[1] === roll[2]
       if (jackpot) {
         while (desuflash && Math.random() < 0.5) {
-          await post(Math.random() < 1 / 10 ? ':dededede-su:' : ':desu:')
+          await post(Math.random() < 1 / 10 ? ':dededede-su:' : ':desu:', 250)
         }
         const display = Math.random() < 1 / 400
           ? (['HMP', 'なまこ'] as const)[Math.floor(Math.random() * 2)]
@@ -127,7 +127,7 @@ const initMessages = () => {
       }
       if (desuflash) {
         while (Math.random() < 0.5) {
-          await post(Math.random() < 1 / 10 ? ':dededede-su:' : ':desu:')
+          await post(Math.random() < 1 / 10 ? ':dededede-su:' : ':desu:', 250)
         }
       }
       const isLast = i === rolls.length - 1


### PR DESCRIPTION
## なぜやるか
desuflashの:desu:投稿は通常の数字投稿より速いテンポで流したい。

## やったこと
- desuflash投稿のsleepを500msから250msに変更
- `post`関数に`ms`引数を追加（デフォルト500ms）

## やってないこと
- 通常の数字投稿・ハズレ投稿のinterval変更

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * メッセージ送信の待ち時間を状況に応じて調整できるようになりました。
  * フラッシュ関連のメッセージが、より短い間隔で送信されるよう改善されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->