### PR TITLE
fix: equalizer ryu_g の表示崩れを修正（CRLF 改行対応）

### DIFF
--- a/src/equalizer/getDataFromGitHub.ts
+++ b/src/equalizer/getDataFromGitHub.ts
@@ -8,7 +8,7 @@ const getDataFromGitHub = async (path: string, octokit) => {
 
   if (Array.isArray(buffer.data)) return
 
-  return Buffer.from(buffer.data.content, 'base64').toString().split('\n')
+  return Buffer.from(buffer.data.content, 'base64').toString().split(/\r?\n/)
 }
 
 export default getDataFromGitHub


### PR DESCRIPTION
closes #467

## なぜやるか

`ryu_g.txt` が Windows 改行（CRLF）で保存されている場合、`split('\n')` で分割すると各行末に `\r` が残る。`formatSpritingBillsData` でテキストフィールドに `\r` が混入し、text-table の出力が `"4/25冷凍ささみ\r  1960"` となる。Slack はこの `\r` を改行として描画するため、金額が次の行に表示されレイアウトが崩れる。

`ryu_g.txt` は CRLF、`sK.txt` は LF で保存されていることを実データの hex ダンプで確認済み。

## やったこと

- `getDataFromGitHub.ts` の `split('\n')` を `split(/\r?\n/)` に変更し、LF・CRLF どちらの改行にも対応

## やってないこと

- `formatSpritingBillsData.ts` 側での trim 処理（今回の修正で不要なため）
- `sK.txt` の改行コード統一（データ側の問題であり、コードで吸収する方針）