### PR TITLE
fix: biome導入で消えたslotのreply_broadcastを再適用

### DIFF
--- a/src/messages.ts
+++ b/src/messages.ts
@@ -112,10 +112,14 @@ const initMessages = () => {
     const desuflash = hasJackpot && Math.random() < 1 / 10
 
     let isFirst = true
-    const post = async (text: string, ms = 500) => {
+    const post = async (text: string, ms = 500, broadcast = false) => {
       if (!isFirst) await sleep(ms)
       isFirst = false
-      await say({ text, thread_ts })
+      await say({
+        text,
+        thread_ts,
+        ...(broadcast ? { reply_broadcast: true } : {}),
+      })
     }
 
     for (let i = 0; i < rolls.length; i++) {
@@ -123,22 +127,34 @@ const initMessages = () => {
       const jackpot = roll[0] === roll[1] && roll[1] === roll[2]
       if (jackpot) {
         while (desuflash && Math.random() < 0.5) {
-          await post(Math.random() < 1 / 10 ? ':dededede-su:' : ':desu:', 250)
+          await post(
+            Math.random() < 1 / 10 ? ':dededede-su:' : ':desu:',
+            250,
+            true,
+          )
         }
         const display =
           Math.random() < 1 / 400
             ? (['HMP', 'なまこ'] as const)[Math.floor(Math.random() * 2)]
             : roll.join(' ')
-        await post(`${display}\n大当たり:de-su:`)
+        await post(`${display}\n大当たり:de-su:`, 500, true)
         return
       }
       if (desuflash) {
         while (Math.random() < 0.5) {
-          await post(Math.random() < 1 / 10 ? ':dededede-su:' : ':desu:', 250)
+          await post(
+            Math.random() < 1 / 10 ? ':dededede-su:' : ':desu:',
+            250,
+            true,
+          )
         }
       }
       const isLast = i === rolls.length - 1
-      await post(isLast ? `${roll.join(' ')}\nハズレ:desu:⋯` : roll.join(' '))
+      await post(
+        isLast ? `${roll.join(' ')}\nハズレ:desu:⋯` : roll.join(' '),
+        500,
+        isLast,
+      )
     }
   })
 }


### PR DESCRIPTION
## なぜやるか

PR #465 で `reply_broadcast: true` を実装してマージしたが、その後の biome formatter 導入 PR (#466) が #465 より古い master を起点にマージされたため、`reply_broadcast` のコードが上書きされて消えてしまっていた。

## やったこと

- biome フォーマット済みの現在の master に対して `reply_broadcast: true` を再適用
- desuflash のフラッシュ投稿・大当たり・ハズレの最終投稿がチャンネルにも共有されるようにした

## やってないこと

- 途中の数字の投稿（大当たり前の各ロール結果）はチャンネルに共有しない

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * 一部のスレッド投稿で、通常投稿に加えてブロードキャスト返信ができるようになりました。
* **不具合修正**
  * ジャックポット時、desuflash 時、最終ハズレ投稿時の投稿動作が、意図した形式で送信されるように調整しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->