### PR TITLE
feat: desuflash大当たり時の最終メッセージを変更

### DIFF
--- a/src/messages.ts
+++ b/src/messages.ts
@@ -133,11 +133,19 @@ const initMessages = () => {
             true,
           )
         }
-        const display =
-          Math.random() < 1 / 400
-            ? (['HMP', 'なまこ'] as const)[Math.floor(Math.random() * 2)]
-            : roll.join(' ')
-        await post(`${display}\n大当たり:de-su:`, 500, true)
+        if (desuflash) {
+          await post(
+            '❗❗❗ :dededede-su: :dededede-su: :dededede-su: ❗❗❗',
+            500,
+            true,
+          )
+        } else {
+          const display =
+            Math.random() < 1 / 400
+              ? (['HMP', 'なまこ'] as const)[Math.floor(Math.random() * 2)]
+              : roll.join(' ')
+          await post(`${display}\n大当たり:de-su:`, 500, true)
+        }
         return
       }
       if (desuflash) {


### PR DESCRIPTION
## Summary

- slotでdesuflash状態のまま大当たりになった場合、最後のメッセージを `❗❗❗ :dededede-su: :dededede-su: :dededede-su: ❗❗❗` に変更
- desuflashなしの大当たりは従来通り `${display}\n大当たり:de-su:` のまま

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * `slot` のジャックポット時の投稿内容が、条件に応じて切り替わるようになりました。
  * 特定の当たり方では、固定の強調メッセージが表示されるようになりました。
  * それ以外のケースでは、これまで通りランダムな表示内容が投稿されます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->